### PR TITLE
create temp copy of products when editing name and id

### DIFF
--- a/src/main/java/org/dasein/cloud/vsphere/compute/TemplateCapabilities.java
+++ b/src/main/java/org/dasein/cloud/vsphere/compute/TemplateCapabilities.java
@@ -120,6 +120,11 @@ public class TemplateCapabilities extends AbstractCapabilities<PrivateCloud> imp
     }
 
     @Override
+    public boolean supportsImageRemoval() throws CloudException, InternalException {
+        return false;  //To change body of implemented methods use File | Settings | File Templates.
+    }
+
+    @Override
     public boolean supportsImageSharing() throws CloudException, InternalException {
         return false;
     }

--- a/src/main/java/org/dasein/cloud/vsphere/compute/Vm.java
+++ b/src/main/java/org/dasein/cloud/vsphere/compute/Vm.java
@@ -1169,10 +1169,17 @@ public class Vm extends AbstractVMSupport<PrivateCloud> {
             // second add same products but augmented with the resource pool info, ordered by pool name
             for( org.dasein.cloud.dc.ResourcePool pool : rps ) {
                 for( VirtualMachineProduct product : jsonProducts ) {
-                    product.setName("Pool " + pool.getName() + "/" + product.getName());
-                    product.setProviderProductId(pool.getProvideResourcePoolId() + ":" + product.getProviderProductId());
+                    VirtualMachineProduct tmp = new VirtualMachineProduct();
+                    tmp.setName("Pool " + pool.getName() + "/" + product.getName());
+                    tmp.setProviderProductId(pool.getProvideResourcePoolId() + ":" + product.getProviderProductId());
+                    tmp.setRootVolumeSize(product.getRootVolumeSize());
+                    tmp.setCpuCount(product.getCpuCount());
+                    tmp.setDescription(product.getDescription());
+                    tmp.setRamSize(product.getRamSize());
+                    tmp.setStandardHourlyRate(product.getStandardHourlyRate());
+
                     if( options == null || options.matches(product) ) {
-                        results.add(product);
+                        results.add(tmp);
                     }
                 }
             }


### PR DESCRIPTION
we want to add to the existing product list with each resource pool
mapping instead of changing name and id of original list items
